### PR TITLE
removing create!

### DIFF
--- a/app/controllers/stockpot/records_controller.rb
+++ b/app/controllers/stockpot/records_controller.rb
@@ -28,7 +28,7 @@ module Stockpot
         if params[:traits].present? && params[:attributes].present?
           FactoryBot.create(factory, *traits, attributes[n])
         elsif params[:traits].blank? && params[:attributes].blank?
-          FactoryBot.create!(factory)
+          FactoryBot.create(factory)
         elsif params[:attributes].blank?
           FactoryBot.create(factory, *traits)
         elsif params[:traits].blank?


### PR DESCRIPTION
## Description

<!--- Provide a general summary description of your changes -->
The `create!()` method was causing certain tests to fail.

## Any additional background context you want to provide?

<!--- Describe your changes in detail -->
I removed the `!` on line 31 of records_controller.rb 

<!--- Please add as much detail in this and the following sections to help us understand what you're doing and why. -->

## Motivation and Context

The inclusion of the `!` in the records_controller.rb file was throwing the error `undefined method 'create!' for FactoryBot:Module`.

<!--- Why is this change required? What problem does it solve? -->

This problem was caused by a mismatch of logic from the Stockpot gem and the FactoryBot gem. This unifies the two.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- !! Please add tests for changes to the code !! -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [ ] I have updated the changelog
- [ ] I have tested this myself.
- [ ] I have added all necessary labels (WIP, review, etc).
- [ ] I have cleaned up redundant template boilerplate from this PR description.
