### PR TITLE
Create GET call for acquiring keys from redis

### DIFF
--- a/app/controllers/stockpot/redis_controller.rb
+++ b/app/controllers/stockpot/redis_controller.rb
@@ -24,5 +24,11 @@ module Stockpot
 
       render json: { status: 201 }
     end
+
+    def keys
+      record = REDIS.keys()
+
+      render json: record.to_json, status: :ok
+    end
   end
 end

--- a/app/controllers/stockpot/redis_controller.rb
+++ b/app/controllers/stockpot/redis_controller.rb
@@ -26,7 +26,7 @@ module Stockpot
     end
 
     def keys
-      record = REDIS.keys()
+      record = REDIS.keys
 
       render json: record.to_json, status: :ok
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,9 @@ Stockpot::Engine.routes.draw do
 
   delete "/clean_database", to: "database_cleaner#index"
 
-  get "/redis", to: "redis#index"
   post "/redis", to: "redis#create"
+  get "/redis", to: "redis#index"
+  get "/redis/keys", to: "redis#keys"
 
   get "/healthz", to: "healthz#index"
 end


### PR DESCRIPTION
## Description

This change will allow the use of a GET request to obtain all keys stored in Redis. 

## Motivation and Context

With the existing GET call, a key could not be obtained without knowing the entirety of the key. With the addition of GET keys, all keys can now be obtained (equivalent to `KEYS *` in Redis CLI).

## How Has This Been Tested?

- Update server gemfile to use this stockpot branch
- Launch server
- Perform any required actions to store data in redis
- Submit a GET request to `"/stockpot/redis/keys"`
- Verify response contains redis keys previously stored

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] I have updated the changelog
- [x] I have tested this myself.
- [x] I have added all necessary labels (WIP, review, etc).
- [x] I have cleaned up redundant template boilerplate from this PR description.
