### PR TITLE
Improve records controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Added
-- createRecords action now allows creation of multiple records.([#18] (github.com/Freshly/stockpot/pull/18/) [dapperDerek])
+- createRecords action now allows creation of multiple records.([#18](github.com/Freshly/stockpot/pull/18/) [dapperDerek])
 - Records controller now allow for multiple calls to the same model, effectively returning the correct data.([#18](github.com/Freshly/stockpot/pull/18/) [dapperDerek])
-- Better error handling, that specifies the model and property that did not pass validation. .([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL])
-- Add support for querying all keys stored in redis. ([#16](https://github.com/Freshly/stockpot/pull/16) [brianharman])
+- Better error handling, that specifies the model and property that did not pass validation.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL])
+- Add support for querying all keys stored in redis.([#16](https://github.com/Freshly/stockpot/pull/16) [brianharman])
 
 ## Fixed
 
-- Validation is now triggering correctly and rolling back any changes within the call.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
-- The create#records now returns based on Ids instead of relying on a specific record order. .([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
-- No more stubbing FactoryBot, there is a method that exposes the class name [#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]]
+- Validation is now triggering correctly and rolling back any changes within the call.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL])
+- The create#records now returns based on Ids instead of relying on a specific record order.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL])
+- No more stubbing FactoryBot, there is a method that exposes the class name.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL])
 
-##[v0.3.1]
+## [v0.3.1] - 2020-04-06
 
 ### Added
-- Fixes the endpoint not working on CI. This is not triggered locally - still puzzled as to the reason for that -. ([#13](https://github.com/Freshly/stockpot/pull/13) [victorFSL])
-- Upgrade a few gems ([#13](https://github.com/Freshly/stockpot/pull/13) [victorFSL])
+- Fixes the endpoint not working on CI. This is not triggered locally - still puzzled as to the reason for that.([#13](https://github.com/Freshly/stockpot/pull/13) [victorFSL])
+- Upgrade a few gems.([#13](https://github.com/Freshly/stockpot/pull/13) [victorFSL])
 
-##[v0.3]
+## [v0.3.0] - 2020-02-10
 
 ### Added
 - Add return errors to a before action to dry up code in the records_controller. ([#9](https://github.com/Freshly/stockpot/pull/9/) [victorFSL])
@@ -121,7 +121,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.1.1]: https://github.com/Freshly/stockpot/releases/tag/v0.1.1
 
 <!-- Contributors -->
-[brianharman]: httpe://githuhb.com/brianharman
+[brianharman]: https://githuhb.com/brianharman
 [corbettbw]: https://github.com/corbettbw
+[dapperDerek]: https://github.com/dapperDerek
 [jaysonesmith]: https://github.com/jaysonesmith
 [victorFSL]: https://github.com/victorFSL
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validation is now triggering correctly and rolling back any changes within the call.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL] 
 - The create#records now returns based on Ids instead of relying on a specific record order. .([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
+- No more stubbing FactoryBot, there is a method that exposes the class name [#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]]
 
 ##[v0.3.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - createRecords action now allows creation of multiple records.([#18](github.com/Freshly/stockpot/pull/18/) [dapperDerek])
-- Records controller now allow for multiple calls to the same model, effectively returning the correct data.([#18](github.com/Freshly/stockpot/pull/18/) [dapperDerek])
+- Records controller now allow for multiple calls to the same model, effectively returning the correct data.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL])
 - Better error handling, that specifies the model and property that did not pass validation.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL])
 - Add support for querying all keys stored in redis.([#16](https://github.com/Freshly/stockpot/pull/16) [brianharman])
 
@@ -126,4 +126,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [dapperDerek]: https://github.com/dapperDerek
 [jaysonesmith]: https://github.com/jaysonesmith
 [victorFSL]: https://github.com/victorFSL
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Records controller now allow for multiple calls to the same model, effectively returning the correct data.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
+- Better error handling, that specifies the model and property that did not pass validation. .([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
 - Add support for querying all keys stored in redis. ([#16](https://github.com/Freshly/stockpot/pull/16) [brianharman])
+
+## Fixed
+
+- Validation is now triggering correctly and rolling back any changes within the call.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL] 
+- The create#records now returns based on Ids instead of relying on a specific record order. .([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
+
+##[v0.3.1]
+
+### Added
 - Fixes the endpoint not working on CI. This is not triggered locally - still puzzled as to the reason for that -. ([#13](https://github.com/Freshly/stockpot/pull/13) [victorFSL])
 - Upgrade a few gems ([#13](https://github.com/Freshly/stockpot/pull/13) [victorFSL])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Added
-
-- Records controller now allow for multiple calls to the same model, effectively returning the correct data.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
-- Better error handling, that specifies the model and property that did not pass validation. .([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
+- createRecords action now allows creation of multiple records.([#18] (github.com/Freshly/stockpot/pull/18/) [dapperDerek])
+- Records controller now allow for multiple calls to the same model, effectively returning the correct data.([#18](github.com/Freshly/stockpot/pull/18/) [dapperDerek])
+- Better error handling, that specifies the model and property that did not pass validation. .([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL])
 - Add support for querying all keys stored in redis. ([#16](https://github.com/Freshly/stockpot/pull/16) [brianharman])
 
 ## Fixed
 
-- Validation is now triggering correctly and rolling back any changes within the call.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL] 
+- Validation is now triggering correctly and rolling back any changes within the call.([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
 - The create#records now returns based on Ids instead of relying on a specific record order. .([#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]
 - No more stubbing FactoryBot, there is a method that exposes the class name [#18](github.com/Freshly/stockpot/pull/18/) [victorFSL]]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The project's repo will look _similar_ to a Rails app, though very pared down. T
 
 ## Releases
 
-When changes on Master need to be released, the following steps should be followed, assuming you have release priveledges.
+When changes on Master need to be released, the following steps should be followed, assuming you have release privileges.
 
 - Update the version number in [version.rb](./lib/stockpot/version.rb)
 - Run `bundle` so that the [Gemfile.lock](Gemfile.lock) gets updated.

--- a/app/controllers/stockpot/helper/errors.rb
+++ b/app/controllers/stockpot/helper/errors.rb
@@ -8,13 +8,13 @@ module Stockpot
 
         case error
         when NameError
-          return_error(error.to_s, error.backtrace.first(5), :bad_request)
+          return_error(error.message, error.backtrace.first(5), :bad_request)
         when PG::Error
-          return_error("Postgres error: #{error}", error.backtrace.first(5), :internal_server_error)
+          return_error("Postgres error: #{error.message}", error.backtrace.first(5), :internal_server_error)
         when ActiveRecord::RecordInvalid, ActiveRecord::Validations, ActiveRecord::RecordNotDestroyed
-          return_error("ActiveRecord error: #{error}", error.backtrace.first(5), :expectation_failed)
+          return_error("In #{error.record.class} class, #{error.message}", error.backtrace.first(5), :expectation_failed)
         else
-          return_error(error.to_s, error.backtrace.first(5),:internal_server_error)
+          return_error(error.message, error.backtrace.first(5),:internal_server_error)
         end
       end
 

--- a/app/controllers/stockpot/helper/errors.rb
+++ b/app/controllers/stockpot/helper/errors.rb
@@ -10,16 +10,16 @@ module Stockpot
         when NameError
           return_error(error.to_s, error.backtrace.first(5), :bad_request)
         when PG::Error
-          return_error("Postgres error: #{error}", error.backtrace.first(5), :server_error)
-        when ActiveRecord::RecordInvalid, ActiveRecord::Validations
-          return_error("ActiveRecord error: #{error}", error.backtrace.first(5), :server_error)
+          return_error("Postgres error: #{error}", error.backtrace.first(5), :internal_server_error)
+        when ActiveRecord::RecordInvalid, ActiveRecord::Validations, ActiveRecord::RecordNotDestroyed
+          return_error("ActiveRecord error: #{error}", error.backtrace.first(5), :expectation_failed)
         else
-          return_error(error.to_s, error.backtrace.first(5),:server_error)
+          return_error(error.to_s, error.backtrace.first(5),:internal_server_error)
         end
       end
 
       def return_error(message, backtrace, status)
-        { json: { error: { status: status, backtrace: backtrace, message: message }}, status: status }
+        render json: { error: { status: status, backtrace: backtrace, message: message }}, status: status
       end
     end
   end

--- a/app/controllers/stockpot/main_controller.rb
+++ b/app/controllers/stockpot/main_controller.rb
@@ -4,7 +4,7 @@ module Stockpot
     include ActiveSupport::Rescuable
     include Helper::Errors
 
-    rescue_from Exception do |exception|
+    rescue_from StandardError do |exception|
       rescue_error(exception)
     end
   end

--- a/app/controllers/stockpot/main_controller.rb
+++ b/app/controllers/stockpot/main_controller.rb
@@ -4,9 +4,8 @@ module Stockpot
     include ActiveSupport::Rescuable
     include Helper::Errors
 
-    rescue_from StandardError do |exception|
-      render rescue_error(exception)
+    rescue_from Exception do |exception|
+      rescue_error(exception)
     end
-    # protect_from_forgery with: :exception
   end
 end

--- a/app/controllers/stockpot/records_controller.rb
+++ b/app/controllers/stockpot/records_controller.rb
@@ -36,7 +36,7 @@ module Stockpot
           ids << @factory.id
         end
       end
-      obj = @factory.class.name.constantize.find(ids)
+      obj = @factory.class.name.constantize.where(id: ids)
 
       render json: obj, status: :created
     end
@@ -50,7 +50,7 @@ module Stockpot
           obj[pluralize(model).camelize(:lower)] = []
 
           class_name.constantize.where(models[i].except(:model)).each do |record|
-            obj[pluralize(model).camelize(:lower)] << record.destroy!
+            obj[pluralize(model).camelize(:lower)] << record if record.destroy!
           end
         end
       end
@@ -69,7 +69,8 @@ module Stockpot
           obj[pluralize(model).camelize(:lower)] = []
 
           class_name.constantize.where(attributes_to_search).each do |record|
-            obj[pluralize(model).camelize(:lower)] << record.update!(update_params)
+            record.update!(update_params)
+            obj[pluralize(model).camelize(:lower)] << class_name.constantize.find(record.id)
           end
         end
       end

--- a/app/controllers/stockpot/records_controller.rb
+++ b/app/controllers/stockpot/records_controller.rb
@@ -70,7 +70,7 @@ module Stockpot
     def update
       ActiveRecord::Base.transaction do
         models.each_with_index do |element, i|
-          model = element[:model].to_s
+          model = element[:model]
           class_name = find_correct_class_name(model)
           update_params = params.permit![:models][i][:update].to_h
           attributes_to_search = models[i].except(:model, :update)

--- a/lib/stockpot/version.rb
+++ b/lib/stockpot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stockpot
-  VERSION = "0.3.2"
+  VERSION = "0.4.0"
 end

--- a/lib/stockpot/version.rb
+++ b/lib/stockpot/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stockpot
-  VERSION = "0.3.0"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
## Description

This takes care of 4 tickets:
- TA-601 -> Improvements to updateRecords.
  - If in the same call there is more than one update to the same model, then the correct records are now returned.
  - Validation will now be triggered and rollbacks will occur.
  - Better errors handling that specify the model and property that did not pass validation.
- TA-608 -> Improvements to createRecords.
  - Records returned will be based on IDs instead of a call to .last()
- TA-609 -> Improvement to deleteRecords.
  - Validations will now be triggered and rollback will occur.
  - Correct records will be returned even if several call to the same model happen.
  - Better errors handling that specify the model and property that did not pass validation.
- TA-610 -> Improvements to getRecords
  - getRecords is more flexible and allows several calls to the same models.

Extra: No more FactoryBot stubbing, let's use a public method instead. [It is both faster and more reliable]
 
## Motivation and Context

We depend on stockpot, so we have to keep maintaining it.

## How Has This Been Tested?

I will share the code privately.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [X] I have updated the changelog
- [X] I have tested this myself.
- [X] I have added all necessary labels (WIP, review, etc).
- [X] I have cleaned up redundant template boilerplate from this PR description.
